### PR TITLE
Fix positional arguments when calling function with arguments

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -1,6 +1,6 @@
 [metadata]
 name = sushipy
-version = 0.1.1
+version = 0.1.2
 author = ksawery29
 author_email = sushicontact1@gmail.com
 long_description = file: README.md

--- a/src/sushipy/execute.py
+++ b/src/sushipy/execute.py
@@ -36,6 +36,7 @@ class TranslateData:
     import_syntax: str
     file_name: str
     call_function: str
+    args: str
 
 
 class Execute:
@@ -47,13 +48,13 @@ class Execute:
         translate_data = {
             "$SUSHI_IMPORT": data.import_syntax.replace("[file-name]", data.file_name),
             "$SUSHI_FUNCTION": data.call_function,
-            "$SUSHI_ARGS": INIT_ARGS,
+            "$SUSHI_ARGS": data.args,
             "$SUSHI_SEMICOLON": ";",
             "$SUSHI_NEWLINE": "\n",
         }
 
         for i, j in translate_data.items():
-            self.temp_file = TEMP_FILE.replace(i, j)
+            self.temp_file = self.temp_file.replace(i, j)
 
     def __init__(self, *args, **kwargs) -> None:
         self.init_args = INIT_ARGS
@@ -73,7 +74,7 @@ class Execute:
 
         self.temp_file = config["temp_file"]["temp_file"]
 
-        data = TranslateData(import_syntax, file_name, call_function)
+        data = TranslateData(import_syntax, file_name, call_function, self.init_args)
         self.translate(data)
 
         self.function()

--- a/src/sushipy/index.py
+++ b/src/sushipy/index.py
@@ -110,12 +110,12 @@ def save():
             fname = x["name"]
 
             args = ""
-            if "arg" in x:
+            if "arg" in x and x["arg"] is not None:
                 args = x["arg"][0]
                 if len(x["arg"]) > 1:
                     args = ",".join(x["arg"][1:])
 
-            f.write(f"def {fname}({args}):\tExecute(file='{file_data_old}', {args})\n")
+            f.write(f"def {fname}({args}):\tExecute('{file_data_old}', {args})\n")
 
         f.close()
 

--- a/tests/test_execute.py
+++ b/tests/test_execute.py
@@ -33,7 +33,7 @@ class TestExecute:
         os.chdir("noarg-temp/")
 
         result = subprocess.run(
-            ["python3.9", "app.py"], capture_output=True, text=True, check=False
+            ["python", "app.py"], capture_output=True, text=True, check=False
         )
         result = result.stdout.split("\n")
 
@@ -47,7 +47,7 @@ class TestExecute:
         os.chdir("arg-temp/")
 
         result = subprocess.run(
-            ["python3.9", "app.py"], capture_output=True, text=True, check=False
+            ["python", "app.py"], capture_output=True, text=True, check=False
         )
         result = result.stdout.split("\n")
 


### PR DESCRIPTION
Use position arguments instead of keyword arguments, fixes passing variables.

Example output of `main.py` from the cpp example in this repo:
```
from sushipy.execute import Execute
def helloWorld(number):	Execute('main.hpp', number)
```

Fixes issue #15 