### PR TITLE
Fix calling functions with arguments and fix saving functions to output file

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,9 +1,9 @@
 name: Test with pytest
 
-on: 
-   push:
-      branches: [main]
-   pull_request:
+on:
+    push:
+        branches: [main]
+    pull_request:
 
 jobs:
     build:
@@ -24,7 +24,7 @@ jobs:
               run: |
                   python -m pip install --upgrade pip
                   python -m pip install -r requirements.txt
-                  python -m pip install -i https://test.pypi.org/simple/ sushipy
+                  python -m pip install .
 
             - name: Test with pytest
               run: |

--- a/examples/math-c/app.py
+++ b/examples/math-c/app.py
@@ -1,19 +1,21 @@
 # pylint: disable=missing-module-docstring
 
 import math
-import timeit
 import random
+import timeit
+
 from sushipy.main import Sushi
 
 D = 100000000
 N = 1000
+
 
 def py_itt_add():
     x = 1.0
     y = 2.0
     result = 0.0
 
-    for i in range(1, D+1):
+    for i in range(1, D + 1):
         result += math.sin(x + i) * math.cos(y + i)
 
     print(result)
@@ -32,6 +34,7 @@ def py_array_sum():
         sum += arr[i]
 
     print(sum)
+
 
 def py_matrix_multiply():
     # Matrices A, B, and C
@@ -56,6 +59,7 @@ def py_matrix_multiply():
     for row in C:
         print(*row)
 
+
 # Run benchmarks of our C code and the equivalent Python code
 if __name__ == "__main__":
     Sushi()
@@ -64,22 +68,36 @@ if __name__ == "__main__":
     from out.main import *
 
     # Time the matrix_multiply() function
-    matrix_multiply_time = timeit.timeit("matrix_multiply()", setup="from __main__ import matrix_multiply", number=1)
+    matrix_multiply_time = timeit.timeit(
+        "matrix_multiply()", setup="from __main__ import matrix_multiply", number=1
+    )
 
     # Time the py_matrix_multiply() function
-    py_matrix_multiply_time = timeit.timeit("py_matrix_multiply()", setup="from __main__ import py_matrix_multiply",number=1)
+    py_matrix_multiply_time = timeit.timeit(
+        "py_matrix_multiply()",
+        setup="from __main__ import py_matrix_multiply",
+        number=1,
+    )
 
     # Time the array_sum() function
-    array_sum_time = timeit.timeit("array_sum()", setup="from __main__ import array_sum", number=3)
+    array_sum_time = timeit.timeit(
+        "array_sum()", setup="from __main__ import array_sum", number=3
+    )
 
     # Time the py_array_sum() function
-    py_array_sum_time = timeit.timeit("py_array_sum()", setup="from __main__ import py_array_sum", number=3)
+    py_array_sum_time = timeit.timeit(
+        "py_array_sum()", setup="from __main__ import py_array_sum", number=3
+    )
 
     # Time the itt_add() function
-    itt_add_time = timeit.timeit("itt_add()", setup="from __main__ import itt_add", number=3)
+    itt_add_time = timeit.timeit(
+        "itt_add()", setup="from __main__ import itt_add", number=3
+    )
 
     # Time the py_itt_add() function
-    py_itt_add_time = timeit.timeit("py_itt_add()", setup="from __main__ import py_itt_add", number=3)
+    py_itt_add_time = timeit.timeit(
+        "py_itt_add()", setup="from __main__ import py_itt_add", number=3
+    )
 
     # Print the results
     print("itt_add() took", itt_add_time, "seconds")
@@ -90,4 +108,3 @@ if __name__ == "__main__":
 
     print("array_sum() took", array_sum_time, "seconds")
     print("py_array_sum() took", py_array_sum_time, "seconds")
-

--- a/examples/math-c/app.py
+++ b/examples/math-c/app.py
@@ -1,10 +1,93 @@
 # pylint: disable=missing-module-docstring
+
+import math
+import timeit
+import random
 from sushipy.main import Sushi
 
+D = 100000000
+N = 1000
+
+def py_itt_add():
+    x = 1.0
+    y = 2.0
+    result = 0.0
+
+    for i in range(1, D+1):
+        result += math.sin(x + i) * math.cos(y + i)
+
+    print(result)
+
+
+def py_array_sum():
+    arr = [0.0] * D
+    sum = 0.0
+
+    # Initialize the array with random values
+    for i in range(D):
+        arr[i] = random.randint(0, 9)
+
+    # Calculate the sum of the array
+    for i in range(D):
+        sum += arr[i]
+
+    print(sum)
+
+def py_matrix_multiply():
+    # Matrices A, B, and C
+    A = [[0 for _ in range(N)] for _ in range(N)]
+    B = [[0 for _ in range(N)] for _ in range(N)]
+    C = [[0 for _ in range(N)] for _ in range(N)]
+
+    # Initialize matrices A and B with random values
+    for i in range(N):
+        for j in range(N):
+            A[i][j] = random.randint(0, 9)
+            B[i][j] = random.randint(0, 9)
+
+    # Perform matrix multiplication
+    for i in range(N):
+        for j in range(N):
+            for k in range(N):
+                C[i][j] += A[i][k] * B[k][j]
+
+    # Print the resulting matrix
+    print("Resulting matrix:")
+    for row in C:
+        print(*row)
+
+# Run benchmarks of our C code and the equivalent Python code
 if __name__ == "__main__":
     Sushi()
 
     # sushi generates code for us to call in Python
-    from out.main import array_sum
+    from out.main import *
 
-    array_sum()
+    # Time the matrix_multiply() function
+    matrix_multiply_time = timeit.timeit("matrix_multiply()", setup="from __main__ import matrix_multiply", number=1)
+
+    # Time the py_matrix_multiply() function
+    py_matrix_multiply_time = timeit.timeit("py_matrix_multiply()", setup="from __main__ import py_matrix_multiply",number=1)
+
+    # Time the array_sum() function
+    array_sum_time = timeit.timeit("array_sum()", setup="from __main__ import array_sum", number=3)
+
+    # Time the py_array_sum() function
+    py_array_sum_time = timeit.timeit("py_array_sum()", setup="from __main__ import py_array_sum", number=3)
+
+    # Time the itt_add() function
+    itt_add_time = timeit.timeit("itt_add()", setup="from __main__ import itt_add", number=3)
+
+    # Time the py_itt_add() function
+    py_itt_add_time = timeit.timeit("py_itt_add()", setup="from __main__ import py_itt_add", number=3)
+
+    # Print the results
+    print("itt_add() took", itt_add_time, "seconds")
+    print("py_itt_add() took", py_itt_add_time, "seconds")
+
+    print("matrix_multiply() took", matrix_multiply_time, "seconds")
+    print("py_matrix_multiply() took", py_matrix_multiply_time, "seconds")
+
+    print("array_sum() took", array_sum_time, "seconds")
+    print("py_array_sum() took", py_array_sum_time, "seconds")
+

--- a/examples/math-c/lib/main.h
+++ b/examples/math-c/lib/main.h
@@ -14,11 +14,11 @@ double itt_add()
     double result = 0.0;
     int i;
 
-    for (i = 1; i <= 1000000; i++) {
+    for (i = 1; i <= D; i++) {
         result += sin(x + i) * cos(y + i);
     }
 
-    return result;
+    printf("%d\n",result);
 }
 
 
@@ -26,12 +26,20 @@ double itt_add()
 
 void matrix_multiply()
 {
-    double A[N][N], B[N][N], C[N][N];
-    int i, j, k;
+    double **A, **B, **C;
+    int i,j, k;
+
+    // Allocate memory for matrices A and B
+    A = (double **)malloc(N * sizeof(double *));
+    B = (double **)malloc(N * sizeof(double *));
+    for (i = 0; i < N; i++) {
+        A[i] = (double *)malloc(N * sizeof(double));
+        B[i] = (double *)malloc(N * sizeof(double));
+    }
 
     // Initialize matrices A and B with random values
     for (i = 0; i < N; i++) {
-        for (j = 0; j < N; j++) {
+        for (int j = 0; j < N; j++) {
             A[i][j] = rand() % 10;
             B[i][j] = rand() % 10;
         }
@@ -46,6 +54,23 @@ void matrix_multiply()
             }
         }
     }
+
+    // Print the resulting matrix
+    printf("Resulting matrix:\n");
+    for (i = 0; i < N; i++) {
+        for (j = 0; j < N; j++) {
+            printf("%f ", C[i][j]);
+        }
+        printf("\n");
+    }
+
+    // Free the allocated memory
+    for (i = 0; i < N; i++) {
+        free(A[i]);
+        free(B[i]);
+    }
+    free(A);
+    free(B);
 }
 
 
@@ -56,7 +81,7 @@ double array_sum()
     double sum = 0.0;
 
     // Allocate memory for the array
-    arr = (double *) malloc(N * sizeof(double));
+    arr = (double *) malloc(D * sizeof(double));
 
     // Initialize the array with random values
     for (i = 0; i < D; i++) {
@@ -70,5 +95,5 @@ double array_sum()
 
     free(arr);
 
-    printf("%d", sum);
+    printf("%d\n", sum);
 }

--- a/examples/math-c/lib/main.h
+++ b/examples/math-c/lib/main.h
@@ -27,19 +27,21 @@ double itt_add()
 void matrix_multiply()
 {
     double **A, **B, **C;
-    int i,j, k;
+    int i, j, k;
 
-    // Allocate memory for matrices A and B
+    // Allocate memory for matrices A, B, and C
     A = (double **)malloc(N * sizeof(double *));
     B = (double **)malloc(N * sizeof(double *));
+    C = (double **)malloc(N * sizeof(double *));
     for (i = 0; i < N; i++) {
         A[i] = (double *)malloc(N * sizeof(double));
         B[i] = (double *)malloc(N * sizeof(double));
+        C[i] = (double *)malloc(N * sizeof(double));
     }
 
     // Initialize matrices A and B with random values
     for (i = 0; i < N; i++) {
-        for (int j = 0; j < N; j++) {
+        for (j = 0; j < N; j++) {
             A[i][j] = rand() % 10;
             B[i][j] = rand() % 10;
         }
@@ -68,9 +70,11 @@ void matrix_multiply()
     for (i = 0; i < N; i++) {
         free(A[i]);
         free(B[i]);
+        free(C[i]);
     }
     free(A);
     free(B);
+    free(C);
 }
 
 

--- a/examples/math-c/sushi.conf
+++ b/examples/math-c/sushi.conf
@@ -12,7 +12,3 @@ extension = c
 
 [index]
 function_pattern = ^[^\n()]+\s+(?!if|for)\b\w+\s*\([^()]*\)\s*$
-
-
-
-

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,6 +1,6 @@
 [metadata]
 name = sushipy
-version = 0.1.1
+version = 0.1.2
 author = ksawery29
 author_email = sushicontact1@gmail.com
 long_description = file: README.md

--- a/src/sushipy/execute.py
+++ b/src/sushipy/execute.py
@@ -45,10 +45,21 @@ class Execute:
     def translate(self, data: TranslateData):
         """translates string (multiple replace)"""
 
+
+        # modify args to only keep the second argument
+        if data.args:
+            args_list = data.args.split()
+            if len(args_list) >= 2:
+                args = args_list[1]
+            else:
+                args = ""
+        else:
+            args = ""
+
         translate_data = {
             "$SUSHI_IMPORT": data.import_syntax.replace("[file-name]", data.file_name),
             "$SUSHI_FUNCTION": data.call_function,
-            "$SUSHI_ARGS": data.args,
+            "$SUSHI_ARGS": args,
             "$SUSHI_SEMICOLON": ";",
             "$SUSHI_NEWLINE": "\n",
         }
@@ -94,7 +105,7 @@ class Execute:
         with open(
             file=f"{path}/temp.{temp_extension}", mode="w", encoding="UTF-8"
         ) as f:
-            f.write(TEMP_FILE)
+            f.write(self.temp_file)
         f.close()
 
         subprocess.call(

--- a/src/sushipy/execute.py
+++ b/src/sushipy/execute.py
@@ -45,7 +45,6 @@ class Execute:
     def translate(self, data: TranslateData):
         """translates string (multiple replace)"""
 
-
         # modify args to only keep the second argument
         if data.args:
             args_list = data.args.split()

--- a/src/sushipy/main.py
+++ b/src/sushipy/main.py
@@ -4,7 +4,7 @@ sushi
 
 import configparser
 import sys
-from os import chdir, getcwd, path
+from os import path
 from os.path import isfile
 
 from rich import print as rich_print


### PR DESCRIPTION
1 . This PR adds functionality to only keep the second argument when calling a function. Previously, sushi would generate a temp file like so:

```bash
sushi   saving indexed functions (lib/main.hpp)
lib/temp.cpp:2:25: warning: character constant too long for its type
    2 |  int main() {helloWorld('main.hpp' 1);}
      |                         ^~~~~~~~~~
lib/temp.cpp: In function 'int main()':
lib/temp.cpp:2:35: error: expected ')' before numeric constant
    2 |  int main() {helloWorld('main.hpp' 1);}
      |                        ~          ^~
      |                                   )

```
In the above, we don't need to pass `main.hpp` to the temp file, only the arguments. This fixes issue #15 
If users want to call functions with multiple arguments, we'll have to fix `translate()` in execute.py.

Passing tests:
```bash
(base) easto@Eastons-MacBook-Air tests % python3.9 -m pytest
========================================================================================================= test session starts ==========================================================================================================
platform darwin -- Python 3.9.16, pytest-7.1.3, pluggy-1.0.0
rootdir: /Users/easto/Library/Mobile Documents/com~apple~CloudDocs/Projects/sushi/tests
plugins: typeguard-2.13.3
collected 2 items                                                                                                                                                                                                                      

test_execute.py ..                                                                                                                                                                                                               [100%]

========================================================================================================== 2 passed in 0.85s ===========================================================================================================
```
2. This PR includes a fix for `save()` in index.py(), sushi would overwrite the generated files if there were multiple functions. This fix writes the import statement only once, and loops over the functions to write to the generated file.

3. This PR also adds C examples for `examples/`, see commit [ec6baef](https://github.com/dev-sushi/sushi/pull/17/commits/ec6baef67233cddeeaf9939b7e4360845be57b41).