### PR TITLE
Cleanup C example and simplify Python code example

### DIFF
--- a/examples/math-c/app.py
+++ b/examples/math-c/app.py
@@ -1,110 +1,20 @@
 # pylint: disable=missing-module-docstring
-
-import math
-import random
 import timeit
 
 from sushipy.main import Sushi
 
-D = 100000000
-N = 1000
-
-
-def py_itt_add():
-    x = 1.0
-    y = 2.0
-    result = 0.0
-
-    for i in range(1, D + 1):
-        result += math.sin(x + i) * math.cos(y + i)
-
-    print(result)
-
-
-def py_array_sum():
-    arr = [0.0] * D
-    sum = 0.0
-
-    # Initialize the array with random values
-    for i in range(D):
-        arr[i] = random.randint(0, 9)
-
-    # Calculate the sum of the array
-    for i in range(D):
-        sum += arr[i]
-
-    print(sum)
-
-
-def py_matrix_multiply():
-    # Matrices A, B, and C
-    A = [[0 for _ in range(N)] for _ in range(N)]
-    B = [[0 for _ in range(N)] for _ in range(N)]
-    C = [[0 for _ in range(N)] for _ in range(N)]
-
-    # Initialize matrices A and B with random values
-    for i in range(N):
-        for j in range(N):
-            A[i][j] = random.randint(0, 9)
-            B[i][j] = random.randint(0, 9)
-
-    # Perform matrix multiplication
-    for i in range(N):
-        for j in range(N):
-            for k in range(N):
-                C[i][j] += A[i][k] * B[k][j]
-
-    # Print the resulting matrix
-    print("Resulting matrix:")
-    for row in C:
-        print(*row)
-
-
-# Run benchmarks of our C code and the equivalent Python code
 if __name__ == "__main__":
     Sushi()
 
     # sushi generates code for us to call in Python
-    from out.main import *
-
-    # Time the matrix_multiply() function
-    matrix_multiply_time = timeit.timeit(
-        "matrix_multiply()", setup="from __main__ import matrix_multiply", number=1
-    )
-
-    # Time the py_matrix_multiply() function
-    py_matrix_multiply_time = timeit.timeit(
-        "py_matrix_multiply()",
-        setup="from __main__ import py_matrix_multiply",
-        number=1,
-    )
-
-    # Time the array_sum() function
-    array_sum_time = timeit.timeit(
-        "array_sum()", setup="from __main__ import array_sum", number=3
-    )
-
-    # Time the py_array_sum() function
-    py_array_sum_time = timeit.timeit(
-        "py_array_sum()", setup="from __main__ import py_array_sum", number=3
-    )
+    from out.main import itt_add , double_number
 
     # Time the itt_add() function
     itt_add_time = timeit.timeit(
-        "itt_add()", setup="from __main__ import itt_add", number=3
+        "itt_add()", setup="from __main__ import itt_add", number=1
     )
-
-    # Time the py_itt_add() function
-    py_itt_add_time = timeit.timeit(
-        "py_itt_add()", setup="from __main__ import py_itt_add", number=3
-    )
-
     # Print the results
     print("itt_add() took", itt_add_time, "seconds")
-    print("py_itt_add() took", py_itt_add_time, "seconds")
 
-    print("matrix_multiply() took", matrix_multiply_time, "seconds")
-    print("py_matrix_multiply() took", py_matrix_multiply_time, "seconds")
-
-    print("array_sum() took", array_sum_time, "seconds")
-    print("py_array_sum() took", py_array_sum_time, "seconds")
+    # Run a function with arguments
+    double_number(5)

--- a/examples/math-c/lib/main.h
+++ b/examples/math-c/lib/main.h
@@ -1,12 +1,9 @@
 #include <stdio.h>
-#include <stdlib.h>
 #include <math.h>
 
-#define N 1000
-#define D 100000000
+#define D 1000000
 
 // Iteratively adds the product of sine(x + i) and cosine(y + i) for i from 1 to 1,000,000.
-
 double itt_add()
 {
     double x = 1.0;
@@ -18,86 +15,12 @@ double itt_add()
         result += sin(x + i) * cos(y + i);
     }
 
-    printf("%d\n",result);
+    printf("%f\n",result);
 }
 
-
-
-
-void matrix_multiply()
+// Double a number
+int double_number(int number)
 {
-    double **A, **B, **C;
-    int i, j, k;
-
-    // Allocate memory for matrices A, B, and C
-    A = (double **)malloc(N * sizeof(double *));
-    B = (double **)malloc(N * sizeof(double *));
-    C = (double **)malloc(N * sizeof(double *));
-    for (i = 0; i < N; i++) {
-        A[i] = (double *)malloc(N * sizeof(double));
-        B[i] = (double *)malloc(N * sizeof(double));
-        C[i] = (double *)malloc(N * sizeof(double));
-    }
-
-    // Initialize matrices A and B with random values
-    for (i = 0; i < N; i++) {
-        for (j = 0; j < N; j++) {
-            A[i][j] = rand() % 10;
-            B[i][j] = rand() % 10;
-        }
-    }
-
-    // Perform matrix multiplication
-    for (i = 0; i < N; i++) {
-        for (j = 0; j < N; j++) {
-            C[i][j] = 0;
-            for (k = 0; k < N; k++) {
-                C[i][j] += A[i][k] * B[k][j];
-            }
-        }
-    }
-
-    // Print the resulting matrix
-    printf("Resulting matrix:\n");
-    for (i = 0; i < N; i++) {
-        for (j = 0; j < N; j++) {
-            printf("%f ", C[i][j]);
-        }
-        printf("\n");
-    }
-
-    // Free the allocated memory
-    for (i = 0; i < N; i++) {
-        free(A[i]);
-        free(B[i]);
-        free(C[i]);
-    }
-    free(A);
-    free(B);
-    free(C);
-}
-
-
-double array_sum()
-{
-    double *arr;
-    int i;
-    double sum = 0.0;
-
-    // Allocate memory for the array
-    arr = (double *) malloc(D * sizeof(double));
-
-    // Initialize the array with random values
-    for (i = 0; i < D; i++) {
-        arr[i] = rand() % 10;
-    }
-
-    // Calculate the sum of the array
-    for (i = 0; i < D; i++) {
-        sum += arr[i];
-    }
-
-    free(arr);
-
-    printf("%d\n", sum);
+    int result = number * 2;
+    printf("%d", result);
 }


### PR DESCRIPTION
This PR reduces the amount of functions in our foreign language (C in this case), and only have two functions for the purpose of examples. One function takes no arguments, and another function does take arguments.

Removed Python-equivalent functions in `app.py` to simplify the example. While timing the function with `timeit` is not necessarily needed, this highlights the benefits of sushi.