### PR TITLE
Fix passing arguments to functions

### DIFF
--- a/src/sushipy/execute.py
+++ b/src/sushipy/execute.py
@@ -48,8 +48,8 @@ class Execute:
         # modify args to only keep the second argument
         if data.args:
             args_list = data.args.split()
-            if len(args_list) >= 2:
-                args = args_list[1]
+            if len(args_list) >= 1:
+                args = args_list[0]
             else:
                 args = ""
         else:


### PR DESCRIPTION
This fixes issue #23, the problem was checking the length of the args for greater than or equal to 2, when it should be 1.

pytest runs successfully, as do the `cpp` and `math-c` examples when passing arguments.

Passing Github Action: https://github.com/dev-sushi/sushi/actions/runs/4451173849