### PR TITLE
Add verbose mode

### DIFF
--- a/src/sushipy/config/extends.py
+++ b/src/sushipy/config/extends.py
@@ -12,6 +12,7 @@ from shutil import rmtree
 
 from git import Repo
 from rich import print as rich_print
+from utils.verbose_print import verbose_print
 
 # pylint: disable=import-error, too-few-public-methods
 from ..cache.main import Cache
@@ -68,7 +69,7 @@ class ConfigExtends:
     def _get_repo(self, data: str, filename: str):
         repourl = f"https://github.com/{data.get('user')}/{data.get('name')}"
 
-        rich_print("[bold yellow]sushi[/bold yellow]   cloning repository")
+        verbose_print(f"[bold green]sushi[/bold green]   cloning repository {repourl}")
 
         # clone repository
         repo = Repo.clone_from(repourl, f"{tempdir}/sushi/")
@@ -87,6 +88,9 @@ class ConfigExtends:
             )
 
         rmtree(f"{tempdir}/sushi/")
+        verbose_print(
+            f"[bold green]sushi[/bold green]   removing file {tempdir}/sushi/"
+        )
 
     def install(self):
         """installs custom config"""

--- a/src/sushipy/execute.py
+++ b/src/sushipy/execute.py
@@ -14,6 +14,7 @@ from os import remove, system
 from os.path import isfile
 
 from .cache.main import Cache
+from .utils.verbose_print import verbose_print
 
 # pylint: disable=import-error
 if isfile("sushicache.py"):
@@ -23,6 +24,7 @@ if isfile("sushicache.py"):
 
 config = configparser.ConfigParser()
 config.read("sushi.conf")
+verbose_flag = config['launch'].getboolean('verbose', fallback=False)
 
 main_config = config["main"]
 launch_config = config["launch"]
@@ -106,7 +108,9 @@ class Execute:
         ) as f:
             f.write(self.temp_file)
         f.close()
-
+        # should print the function name for debugging purposes
+        verbose_print(
+            f"[bold green]sushi[/bold green]   executing function ", verbose_flag)
         subprocess.call(
             shlex.split(
                 launch_config["exec_command"].replace(

--- a/src/sushipy/execute.py
+++ b/src/sushipy/execute.py
@@ -24,7 +24,6 @@ if isfile("sushicache.py"):
 
 config = configparser.ConfigParser()
 config.read("sushi.conf")
-verbose_flag = config['launch'].getboolean('verbose', fallback=False)
 
 main_config = config["main"]
 launch_config = config["launch"]
@@ -75,7 +74,8 @@ class Execute:
         # get from what function was this called
         call_function = inspect.stack()[1].function
         verbose_print(
-            f"[bold green]sushi[/bold green]   finding function {call_function}", verbose_flag)
+            f"[bold green]sushi[/bold green]   finding function {call_function}"
+        )
         self.init_args = re.sub("[()]", "", rf"{args}".replace(",", ""))
         import_syntax = launch_config["import_syntax"]
 
@@ -110,8 +110,7 @@ class Execute:
             f.write(self.temp_file)
         f.close()
         # should print the function name for debugging purposes
-        verbose_print(
-            f"[bold green]sushi[/bold green]   executing function ", verbose_flag)
+        verbose_print(f"[bold green]sushi[/bold green]   executing function ")
         subprocess.call(
             shlex.split(
                 launch_config["exec_command"].replace(

--- a/src/sushipy/execute.py
+++ b/src/sushipy/execute.py
@@ -48,8 +48,8 @@ class Execute:
         # modify args to only keep the second argument
         if data.args:
             args_list = data.args.split()
-            if len(args_list) >= 2:
-                args = args_list[1]
+            if len(args_list) >= 1:
+                args = args_list[0]
             else:
                 args = ""
         else:

--- a/src/sushipy/execute.py
+++ b/src/sushipy/execute.py
@@ -74,7 +74,8 @@ class Execute:
 
         # get from what function was this called
         call_function = inspect.stack()[1].function
-
+        verbose_print(
+            f"[bold green]sushi[/bold green]   finding function {call_function}", verbose_flag)
         self.init_args = re.sub("[()]", "", rf"{args}".replace(",", ""))
         import_syntax = launch_config["import_syntax"]
 

--- a/src/sushipy/index.py
+++ b/src/sushipy/index.py
@@ -7,6 +7,7 @@ import re
 from contextlib import suppress
 from os import listdir, mkdir, path
 from os.path import exists, isfile
+from rich import print as rich_print
 
 from .cache.main import Cache
 from .stores import MULTIPLE_FILES
@@ -110,7 +111,7 @@ def save():
         # Write each function to our created file
         # pylint: disable=line-too-long
         for x in DATA:
-            verbose_print(
+            rich_print(
                 f"[bold yellow]sushi[/bold yellow]   saving indexed function '{x['name']}' ({x['file']}){print_space}",
                 verbose_flag)
             # pylint: enable=line-too-long
@@ -127,7 +128,7 @@ def save():
 
         f.close()
 
-        verbose_print(
+        rich_print(
             f"[bold green]sushi[/bold green]   saved indexed functions to out/{file_data}.py{print_space}", verbose_flag)
 
 

--- a/src/sushipy/index.py
+++ b/src/sushipy/index.py
@@ -7,6 +7,7 @@ import re
 from contextlib import suppress
 from os import listdir, mkdir, path
 from os.path import exists, isfile
+
 from rich import print as rich_print
 
 from .cache.main import Cache
@@ -21,18 +22,18 @@ if isfile("sushicache.py"):
 
 config = configparser.ConfigParser()
 config.read("sushi.conf")
-verbose_flag = config['launch'].getboolean('verbose', fallback=False)
 
 DATA = []
 
 
 def _open_find(
-        file,
-        function_pattern,
+    file,
+    function_pattern,
 ):
     """finds all functions by using regex from sushi.conf"""
     verbose_print(
-        f"[bold green]sushi[/bold green]   finding functions in {file} from sushi.conf", verbose_flag)
+        f"[bold green]sushi[/bold green]   finding functions in {file} from sushi.conf"
+    )
     # first, open file
     with open(file=file, mode="r", encoding="UTF-8") as f:
         lines = f.read().split("\n")
@@ -52,7 +53,8 @@ def _open_find(
                 arg_data = get_arg(name, data)
                 DATA.append(data | {"arg": arg_data})
                 verbose_print(
-                    f"[bold green]sushi[/bold green]   function '{name}' takes args: {arg_data}", verbose_flag)
+                    f"[bold green]sushi[/bold green]   function '{name}' takes args: {arg_data}"
+                )
                 # pylint: enable=unsupported-binary-operation
 
         f.close()
@@ -79,8 +81,7 @@ def find():
 
     # save indexed functions to cache so we dont have to re-index every launch
     with suppress(NameError):
-        verbose_print(
-            f"[bold green]sushi[/bold green]   updating cache", verbose_flag)
+        verbose_print(f"[bold green]sushi[/bold green]   updating cache")
         Cache.update(
             Cache,
             f"INDEXED_FUNCTIONS = {sushicache.INDEXED_FUNCTIONS}",
@@ -112,8 +113,8 @@ def save():
         # pylint: disable=line-too-long
         for x in DATA:
             rich_print(
-                f"[bold yellow]sushi[/bold yellow]   saving indexed function '{x['name']}' ({x['file']}){print_space}",
-                verbose_flag)
+                f"[bold yellow]sushi[/bold yellow]   saving indexed function '{x['name']}' ({x['file']}){print_space}"
+            )
             # pylint: enable=line-too-long
 
             fname = x["name"]
@@ -129,13 +130,13 @@ def save():
         f.close()
 
         rich_print(
-            f"[bold green]sushi[/bold green]   saved indexed functions to out/{file_data}.py{print_space}", verbose_flag)
+            f"[bold green]sushi[/bold green]   saved indexed functions to out/{file_data}.py{print_space}"
+        )
 
 
 def get_arg(name: str, data: any):
     """gets all arguments from function"""
-    verbose_print(
-        f"[bold green]sushi[/bold green]   getting all args for '{name}'", verbose_flag)
+    verbose_print(f"[bold green]sushi[/bold green]   getting all args for '{name}'")
     args = []
     find_data = find_dict(name, [data], "name")
 
@@ -166,12 +167,14 @@ def get_arg(name: str, data: any):
                     multiple_args.pop()
                     multiple_args.append(last_item.replace(")", ""))
                     verbose_print(
-                        f"[bold green]sushi[/bold green]  function '{name}' uses args: {multiple_args}", verbose_flag)
+                        f"[bold green]sushi[/bold green]  function '{name}' uses args: {multiple_args}"
+                    )
 
                     return multiple_args
 
         elif split_args != ")":
             args.append(split_args.replace(")", ""))
         verbose_print(
-            f"[bold green]sushi[/bold green]   function '{name}' uses args: {args}", verbose_flag)
+            f"[bold green]sushi[/bold green]   function '{name}' uses args: {args}"
+        )
         return args

--- a/src/sushipy/stores.py
+++ b/src/sushipy/stores.py
@@ -9,6 +9,7 @@ config.read("sushi.conf")
 
 MULTIPLE_FILES = False
 
+
 split_path = config["main"]["lib_path"].split("/")
 if split_path[-1] == "*":
     MULTIPLE_FILES = True

--- a/src/sushipy/utils/verbose_print.py
+++ b/src/sushipy/utils/verbose_print.py
@@ -1,6 +1,16 @@
+import configparser
+
 from rich import print as rich_print
 
-def verbose_print(message:str, verbose:bool):
+# TODO: maybe move to stores.py
+
+config = configparser.ConfigParser()
+config.read("sushi.conf")
+
+verbose_flag = config["launch"].getboolean("verbose", fallback=False)
+
+
+def verbose_print(message: str):
     """
     Prints a verbose message using rich library if the 'verbose' flag is set to True.
 
@@ -11,5 +21,5 @@ def verbose_print(message:str, verbose:bool):
     Example:
         verbose_print("This is a verbose message", verbose=True)
     """
-    if verbose:
+    if verbose_flag:
         rich_print(message)

--- a/src/sushipy/utils/verbose_print.py
+++ b/src/sushipy/utils/verbose_print.py
@@ -1,0 +1,15 @@
+from rich import print as rich_print
+
+def verbose_print(message:str, verbose:bool):
+    """
+    Prints a verbose message using rich library if the 'verbose' flag is set to True.
+
+    Args:
+        message (str): The message to be printed.
+        verbose (bool): A flag to determine if the message should be printed or not.
+
+    Example:
+        verbose_print("This is a verbose message", verbose=True)
+    """
+    if verbose:
+        rich_print(message)


### PR DESCRIPTION
This PR adds verbose printing for debugging purposes to sushi. The goal of this pull request is to increase the visibility of the workings of sushi when processing foreign language files. This address issues #21 

`rich_print()` has been moved to `utils/verbose_print` and is controlled by a boolean flag.

Users can enable the verbose flag by modifying their sushi.conf file. Example:
```
[main]
lang = h
lib_path = lib/main.h

[launch]
exec_command = gcc -o lib/out [file-name]
import_syntax = #include "[file-name]"
verbose = yes
```

